### PR TITLE
Fix length when reading websocket frame

### DIFF
--- a/lib/protocol/websocket/frame.rb
+++ b/lib/protocol/websocket/frame.rb
@@ -147,7 +147,7 @@ module Protocol
 					buffer = stream.read(2) or raise EOFError, "Could not read length!"
 					length = buffer.unpack('n').first
 				elsif length == 127
-					buffer = stream.read(4) or raise EOFError, "Could not read length!"
+					buffer = stream.read(8) or raise EOFError, "Could not read length!"
 					length = buffer.unpack('Q>').first
 				end
 				

--- a/spec/protocol/websocket/connection_spec.rb
+++ b/spec/protocol/websocket/connection_spec.rb
@@ -66,4 +66,24 @@ RSpec.describe Protocol::WebSocket::Connection do
 			expect(client.read_frame).to be == ping_frame.reply
 		end
 	end
+
+	context "message length" do
+		it "can handle a short message (<126)" do
+			client.write_frame(Protocol::WebSocket::TextFrame.new(true).tap{|frame| frame.pack("a" * 15)})
+			message = subject.read
+			expect(message.size).to be == 15
+		end
+
+		it "can handle a medium message (<65k)" do
+			client.write_frame(Protocol::WebSocket::TextFrame.new(true).tap{|frame| frame.pack("a" * 60_000)})
+			message = subject.read
+			expect(message.size).to be == 60_000
+		end
+
+		it "can handle large message (>65k)" do
+			client.write_frame(Protocol::WebSocket::TextFrame.new(true).tap{|frame| frame.pack("a" * 90_000)})
+			message = subject.read
+			expect(message.size).to be == 90_000
+		end
+	end
 end


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc6455 page 29:
> If 127, the following 8 bytes interpreted as a 64-bit unsigned integer

I've verified that changing the 4 to an 8 makes this gem work locally. Otherwise it raises ``protocol-websocket-0.7.2/lib/protocol/websocket/frame.rb:154:in `read': undefined method `>' for nil:NilClass (NoMethodError)``