### PR TITLE
Implement enough to make this pass autobahn-testsuite

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -32,13 +32,22 @@ jobs:
             ruby: head
             experimental: true
     
+    env:
+      BUNDLE_WITH: autobahn_tests
+    
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
     
     - name: Run tests
       timeout-minutes: 5
       run: ${{matrix.env}} bundle exec rspec
+    - name: Run Autobahn server tests
+      timeout-minutes: 5
+      run: ${{matrix.env}} ruby autobahn-tests/autobahn-server-tests.rb

--- a/autobahn-tests/autobahn-echo-server.ru
+++ b/autobahn-tests/autobahn-echo-server.ru
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S falcon serve --bind http://127.0.0.1:9001 --count 1 -c
+
+require "async/websocket/adapters/rack"
+
+# TODO: This should probably be part of the library long-term
+class RawConnection < Async::WebSocket::Connection
+  def parse(buffer)
+    buffer
+  end
+
+  def dump(buffer)
+    buffer
+  end
+end
+
+app = lambda do |env|
+  Async::WebSocket::Adapters::Rack.open(env, handler: RawConnection) do |c|
+    while message = c.read
+      c.write(message)
+    end
+  end
+end
+
+run app

--- a/autobahn-tests/autobahn-server-tests.rb
+++ b/autobahn-tests/autobahn-server-tests.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+require "json"
+
+Kernel.system("pip install autobahntestsuite", exception: true)
+
+falcon = Process.spawn("bundle exec #{__dir__}/autobahn-echo-server.ru", pgroup: true)
+falcon_pg = Process.getpgid(falcon)
+
+Kernel.system("wstest -m fuzzingclient", chdir: __dir__, exception: true)
+
+Process.kill("KILL", -falcon_pg)
+
+result = JSON.parse(File.read("/tmp/autobahn-server/index.json"))["protocol-websocket"]
+
+FileUtils.rm_r("/tmp/autobahn-server/")
+
+failed = result.select { |_, e| e["behavior"] != "OK" || e["behaviorClose"] != "OK" }
+
+puts "#{result.count - failed.count} / #{result.count} tests OK"
+
+failed.each { |k, _| puts "#{k} failed" }
+
+exit(1) if failed.count > 0

--- a/autobahn-tests/fuzzingclient.json
+++ b/autobahn-tests/fuzzingclient.json
@@ -1,0 +1,14 @@
+{
+   "outdir": "/tmp/autobahn-server",
+   "servers": [
+      {
+         "agent": "protocol-websocket",
+         "url": "ws://127.0.0.1:9001"
+      }
+   ],
+   "cases": ["*"],
+   "exclude-cases": ["6.4.*", "7.1.6", "7.13.*", "12.*", "13.*"],
+   "exclude-agent-cases": {
+     "protocol-websocket": ["3.3", "7.7.*"]
+   }
+}

--- a/gems.rb
+++ b/gems.rb
@@ -7,3 +7,8 @@ group :maintenance, optional: true do
 	gem "bake-bundler"
 	gem "bake-modernize"
 end
+
+group :autobahn_tests, optional: true do
+	gem "async-websocket", github: "socketry/async-websocket"
+	gem "falcon"
+end

--- a/lib/protocol/websocket/binary_frame.rb
+++ b/lib/protocol/websocket/binary_frame.rb
@@ -29,6 +29,10 @@ module Protocol
 				true
 			end
 			
+			def decode_message(buffer)
+				buffer
+			end
+			
 			def apply(connection)
 				connection.receive_binary(self)
 			end


### PR DESCRIPTION
This adds features and fixes enough old ones that all tests in https://github.com/crossbario/autobahn-testsuite passes, even if some of them do so non-strictly by either not failing early or by simply not implementing any extensions.

## Description

Previously there was a lot of edge-cases related to error handling, framing, and closing connections that was not implemented. I implemented enough new features that you can now run the autobahn-testsuite and it passes with the following echo server.

[autobahn-test-results.zip](https://github.com/socketry/protocol-websocket/files/6608211/autobahn-test-results.zip)

```
require "async/websocket/adapters/rack"

class RawConnection < Async::WebSocket::Connection
  def parse(buffer)
    buffer
  end

  def dump(buffer)
    buffer
  end
end

app = lambda do |env|
  response = Async::WebSocket::Adapters::Rack.open(env, handler: RawConnection) do |connection|
    while message = connection.read
      connection.write(message)
    end
  end

  if response
    response
  else
    [406, {}, ["Please use websockets"]]
  end
end

run app
```

The most important changes is that the framing is fixed in text frames and control frames, we try to implement the closing handshake, and that we check for reserved bits that we don't support yet (because they have not been specified at this moment).

There is a workaround for a bug in Async::IO for 0-length reads in there, it should probably be fixed in Async::IO and then removed from here before this is merged. We should probably also add these tests to CI, but I'm going to call for the local CI-expert @olleolleolle to help with that.

### Types of Changes

- Bug fix.
- New feature.
- Maintenance.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
- [x] I have run external tests