### PR TITLE
Use the term close reason

### DIFF
--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -51,8 +51,8 @@ module Protocol
 				@state == :closed
 			end
 			
-			def close(code = Error::NO_ERROR, message = "")
-				send_close(code, message) unless closed?
+			def close(code = Error::NO_ERROR, reason = "")
+				send_close(code, reason) unless closed?
 				
 				@framer.close
 			end
@@ -139,7 +139,7 @@ module Protocol
 				send_close(code, reason)
 				
 				if code and code != Error::NO_ERROR
-					raise ClosedError.new message, code
+					raise ClosedError.new reason, code
 				end
 			end
 			


### PR DESCRIPTION
## Description

This contains a typographical fix and a bug fix. This makes sure we consistently use the term "close reason" instead of "close message" to refer to what the spec calls close reason (https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.6). It also fixes a reference to a non-existing variable named message.

### Types of Changes

- Bug fix.
- Maintenance.

### Testing

- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
