### PR TITLE
More robust handling of `Connection#close`.

### DIFF
--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -60,7 +60,15 @@ module Protocol
 			end
 			
 			def close(code = Error::NO_ERROR, reason = "")
-				send_close(code, reason) unless closed?
+				unless closed?
+					begin
+						send_close(code, reason)
+					rescue
+						# Ignore.
+					end
+					
+					@state = :closed
+				end
 				
 				@framer.close
 			end

--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -125,7 +125,11 @@ module Protocol
 				# If we're already closed, then we don't need to send a close frame. Otherwise, according to the RFC, we should echo the close frame. However, it's possible it will fail to send if the connection is already closed.
 				unless @state == :closed
 					@state = :closed
-					send_close(code, reason)
+					begin
+						send_close(code, reason)
+					rescue
+						# Ignore.
+					end
 				end
 				
 				if code and code != Error::NO_ERROR
@@ -198,12 +202,8 @@ module Protocol
 				frame = CloseFrame.new(mask: @mask)
 				frame.pack(code, reason)
 				
-				begin
-					self.write_frame(frame)
-					self.flush
-				rescue EOFError, Errno::EPIPE
-					# Ignore.
-				end
+				self.write_frame(frame)
+				self.flush
 			end
 			
 			# Write a message to the connection.

--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -204,8 +204,6 @@ module Protocol
 				rescue EOFError, Errno::EPIPE
 					# Ignore.
 				end
-				
-				@state = :closed
 			end
 			
 			# Write a message to the connection.

--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -71,6 +71,8 @@ module Protocol
 						# Ignore.
 					end
 				end
+				
+				return self
 			end
 			
 			def closed?

--- a/test/protocol/websocket/connection.rb
+++ b/test/protocol/websocket/connection.rb
@@ -156,7 +156,7 @@ describe Protocol::WebSocket::Connection do
 				connection.read_frame
 			end.to raise_exception(EOFError, message: be =~ /Fake error/)
 			
-			expect(connection).not.to be(:closed?)
+			expect(connection).to be(:closed?)
 			
 			frame = client.read_frame
 			expect(frame).to be_a(Protocol::WebSocket::CloseFrame)

--- a/test/protocol/websocket/connection.rb
+++ b/test/protocol/websocket/connection.rb
@@ -15,12 +15,20 @@ describe Protocol::WebSocket::Connection do
 	
 	let(:connection) {subject.new(server)}
 	
-	it "can manipulate open/closed state" do
-		expect(connection).not.to be(:closed?)
-		connection.close!
-		expect(connection).to be(:closed?)
-		connection.open!
-		expect(connection).not.to be(:closed?)
+	with '#close!' do
+		it "can manipulate open/closed state" do
+			expect(connection).not.to be(:closed?)
+			connection.close!
+			expect(connection).to be(:closed?)
+			connection.open!
+			expect(connection).not.to be(:closed?)
+		end
+		
+		it "ignores write failures" do
+			server.close
+			connection.close!
+			expect(connection).to be(:closed?)
+		end
 	end
 	
 	it "doesn't generate mask by default" do

--- a/test/protocol/websocket/connection.rb
+++ b/test/protocol/websocket/connection.rb
@@ -156,10 +156,10 @@ describe Protocol::WebSocket::Connection do
 				connection.read_frame
 			end.to raise_exception(EOFError, message: be =~ /Fake error/)
 			
-			expect(connection).to be(:closed?)
+			expect(connection).not.to be(:closed?)
 			
-			# frame = client.read_frame
-			# expect(frame).to be_a(Protocol::WebSocket::CloseFrame)
+			frame = client.read_frame
+			expect(frame).to be_a(Protocol::WebSocket::CloseFrame)
 		end
 	end
 	


### PR DESCRIPTION
[The WebSocket RFC states](https://www.rfc-editor.org/rfc/rfc6455):

```
If an endpoint receives a Close frame and did not previously send a
   Close frame, the endpoint MUST send a Close frame in response.  (When
   sending a Close frame in response, the endpoint typically echos the
   status code it received.)  It SHOULD do so as soon as practical.  An
   endpoint MAY delay sending a Close frame until its current message is
   sent (for instance, if the majority of a fragmented message is
   already sent, an endpoint MAY send the remaining fragments before
   sending a Close frame).  However, there is no guarantee that the
   endpoint that has already sent a Close frame will continue to process
   data.

   After both sending and receiving a Close message, an endpoint
   considers the WebSocket connection closed and MUST close the
   underlying TCP connection.  The server MUST close the underlying TCP
   connection immediately; the client SHOULD wait for the server to
   close the connection but MAY close the connection at any time after
   sending and receiving a Close message, e.g., if it has not received a
   TCP Close from the server in a reasonable time period.

   If a client and server both send a Close message at the same time,
   both endpoints will have sent and received a Close message and should
   consider the WebSocket connection closed and close the underlying TCP
   connection.
```

This is not handled correctly in the current code, as we mostly don't care about waiting for a close message. This PR makes ignores failures to write the close message.

https://github.com/socketry/async-websocket/issues/50

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
