### PR TITLE
Transition into closed state only occurs on READING a close frame.

### DIFF
--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -101,6 +101,12 @@ module Protocol
 				frame.apply(self)
 				
 				return frame
+			rescue ProtocolError => error
+				close(error.code, error.message)
+				raise
+			rescue => error
+				close(Error::PROTOCOL_ERROR, error.message)
+				raise
 			end
 			
 			def write_frame(frame)
@@ -236,9 +242,6 @@ module Protocol
 						return frames.first.read_message(buffer)
 					end
 				end
-			rescue ProtocolError => error
-				close(error.code, error.message)
-				raise
 			end
 		end
 	end

--- a/lib/protocol/websocket/connection.rb
+++ b/lib/protocol/websocket/connection.rb
@@ -200,6 +200,7 @@ module Protocol
 				write_frame(@writer.pack_binary_frame(buffer, **options))
 			end
 			
+			# Send a control frame with data containing a specified control sequence to begin the closing handshake. Does not close the connection, until the remote end responds with a close frame.
 			def send_close(code = Error::NO_ERROR, reason = "")
 				frame = CloseFrame.new(mask: @mask)
 				frame.pack(code, reason)

--- a/test/protocol/websocket/connection.rb
+++ b/test/protocol/websocket/connection.rb
@@ -149,6 +149,8 @@ describe Protocol::WebSocket::Connection do
 		end
 		
 		it "closes connection if general exception occurs during processing" do
+			skip "This test is broken"
+			
 			frame = Protocol::WebSocket::TextFrame.new
 			frame.pack "Hello World!"
 			
@@ -182,6 +184,14 @@ describe Protocol::WebSocket::Connection do
 	end
 	
 	with '#receive_close' do
+		it "does not close the underlying connection" do
+			close_frame = Protocol::WebSocket::CloseFrame.new
+			close_frame.pack
+			
+			expect(client).not.to receive(:close)
+			close_frame.apply(connection)
+		end
+		
 		it "raises an exception when the close frame has an error code" do
 			close_frame = Protocol::WebSocket::CloseFrame.new
 			close_frame.pack(1001, "Fake error message")

--- a/test/protocol/websocket/connection.rb
+++ b/test/protocol/websocket/connection.rb
@@ -149,8 +149,6 @@ describe Protocol::WebSocket::Connection do
 		end
 		
 		it "closes connection if general exception occurs during processing" do
-			skip "This test is broken"
-			
 			frame = Protocol::WebSocket::TextFrame.new
 			frame.pack "Hello World!"
 			


### PR DESCRIPTION
> Either peer can send a control frame with data containing a specified
   control sequence to begin the closing handshake (detailed in
   [Section 5.5.1](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1)).  Upon receiving such a frame, the other peer sends a
   Close frame in response, if it hasn't already sent one.  Upon
   receiving _that_ control frame, the first peer then closes the
   connection, safe in the knowledge that no further data is
   forthcoming.