### PR TITLE
Fix handling of optional compression.

### DIFF
--- a/lib/protocol/websocket/extension/compression/deflate.rb
+++ b/lib/protocol/websocket/extension/compression/deflate.rb
@@ -54,21 +54,29 @@ module Protocol
 					attr :context_takeover
 					
 					def pack_text_frame(buffer, compress: true, **options)
-						buffer = self.deflate(buffer)
+						if compress
+							buffer = self.deflate(buffer)
+						end
 						
 						frame = @parent.pack_text_frame(buffer, **options)
 						
-						frame.flags |= Frame::RSV1
+						if compress
+							frame.flags |= Frame::RSV1
+						end
 						
 						return frame
 					end
 					
 					def pack_binary_frame(buffer, compress: false, **options)
-						buffer = self.deflate(buffer)
+						if compress
+							buffer = self.deflate(buffer)
+						end
 						
 						frame = @parent.pack_binary_frame(buffer, **options)
 						
-						frame.flags |= Frame::RSV1
+						if compress
+							frame.flags |= Frame::RSV1
+						end
 						
 						return frame
 					end

--- a/lib/protocol/websocket/extension/compression/inflate.rb
+++ b/lib/protocol/websocket/extension/compression/inflate.rb
@@ -54,11 +54,10 @@ module Protocol
 						
 						frame = frames.first
 						
-						if frame.flags & Frame::RSV1
+						if frame.flag?(Frame::RSV1)
 							buffer = self.inflate(buffer)
+							frame.flags &= ~Frame::RSV1
 						end
-						
-						frame.flags &= ~Frame::RSV1
 						
 						return buffer
 					end

--- a/lib/protocol/websocket/frame.rb
+++ b/lib/protocol/websocket/frame.rb
@@ -34,6 +34,10 @@ module Protocol
 				@payload = payload
 			end
 			
+			def flag?(value)
+				@flags & value != 0
+			end
+			
 			def <=> other
 				to_ary <=> other.to_ary
 			end

--- a/test/protocol/websocket/extension/compression.rb
+++ b/test/protocol/websocket/extension/compression.rb
@@ -43,12 +43,36 @@ describe Protocol::WebSocket::Extension::Compression do
 			end
 		end
 		
+		it "can send and receive a text message without compression" do
+			Async::WebSocket::Client.connect(endpoint) do |client|
+				expect(client.writer).to be_a(Protocol::WebSocket::Extension::Compression::Deflate)
+				expect(client.reader).to be_a(Protocol::WebSocket::Extension::Compression::Inflate)
+				
+				client.send_text("Hello World", compress: false)
+				client.flush
+				
+				expect(client.read).to be == "Hello World"
+			end
+		end
+		
 		it "can send and receive a binary message using compression" do
 			Async::WebSocket::Client.connect(endpoint) do |client|
 				expect(client.writer).to be_a(Protocol::WebSocket::Extension::Compression::Deflate)
 				expect(client.reader).to be_a(Protocol::WebSocket::Extension::Compression::Inflate)
 				
-				client.send_binary("Hello World")
+				client.send_binary("Hello World", compress: true)
+				client.flush
+				
+				expect(client.read).to be == "Hello World"
+			end
+		end
+		
+		it "can send and receive a binary message without compression" do
+			Async::WebSocket::Client.connect(endpoint) do |client|
+				expect(client.writer).to be_a(Protocol::WebSocket::Extension::Compression::Deflate)
+				expect(client.reader).to be_a(Protocol::WebSocket::Extension::Compression::Inflate)
+				
+				client.send_binary("Hello World", compress: false)
 				client.flush
 				
 				expect(client.read).to be == "Hello World"


### PR DESCRIPTION
Safari sometimes skips `permessage-deflate` using the frame flags as is appropriate, but it was not handled correctly in `Inflate#unpack_frames`. The flag check was always true regardless of the flag not being set due to a bug in the code.

We also fix the handling of the `compress:` option.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
