### PR TITLE
Reduced need for JSONMessage.

### DIFF
--- a/lib/protocol/websocket/coder.rb
+++ b/lib/protocol/websocket/coder.rb
@@ -1,0 +1,9 @@
+require_relative 'coder/json'
+
+module Protocol
+	module WebSocket
+		module Coder
+			DEFAULT = JSON::DEFAULT
+		end
+	end
+end

--- a/lib/protocol/websocket/coder/json.rb
+++ b/lib/protocol/websocket/coder/json.rb
@@ -1,0 +1,23 @@
+require 'json'
+
+module Protocol
+	module WebSocket
+		module Coder
+			class JSON
+				def initialize(**options)
+					@options = options
+				end
+				
+				def parse(buffer)
+					::JSON.parse(buffer, **@options)
+				end
+				
+				def generate(object)
+					::JSON.generate(object, **@options)
+				end
+				
+				DEFAULT = new(symbolize_names: true)
+			end
+		end
+	end
+end

--- a/lib/protocol/websocket/json_message.rb
+++ b/lib/protocol/websocket/json_message.rb
@@ -3,29 +3,20 @@
 # Released under the MIT License.
 # Copyright, 2022-2023, by Samuel Williams.
 
-require 'json'
-
 require_relative 'message'
+
+warn "Protocol::WebSocket::JSONMessage is deprecated. Use Protocol::WebSocket::TextMessage instead."
 
 module Protocol
 	module WebSocket
+		# @deprecated Use {TextMessage} instead.
 		class JSONMessage < TextMessage
 			def self.wrap(message)
-				if message.is_a?(TextMessage)
-					self.new(message.buffer)
-				end
+				message
 			end
 			
 			def self.generate(object)
 				self.new(JSON.generate(object))
-			end
-			
-			def parse(symbolize_names: true, **options)
-				JSON.parse(@buffer, symbolize_names: symbolize_names, **options)
-			end
-			
-			def to_h
-				parse.to_h
 			end
 		end
 	end

--- a/lib/protocol/websocket/message.rb
+++ b/lib/protocol/websocket/message.rb
@@ -4,6 +4,7 @@
 # Copyright, 2022-2023, by Samuel Williams.
 
 require_relative 'frame'
+require_relative 'coder'
 
 module Protocol
 	module WebSocket
@@ -29,6 +30,21 @@ module Protocol
 			
 			def encoding
 				@buffer.encoding
+			end
+			
+			# Generate a message from a value using the given coder.
+			# @property value [Object] The value to encode.
+			# @property coder [Coder] The coder to use. Defaults to JSON.
+			def self.generate(value, coder = Coder::DEFAULT)
+				new(coder.generate(value))
+			end
+			
+			def parse(coder = Coder::DEFAULT)
+				coder.parse(@buffer)
+			end
+			
+			def to_h(...)
+				parse(...).to_h
 			end
 		end
 		

--- a/test/protocol/websocket/message.rb
+++ b/test/protocol/websocket/message.rb
@@ -12,4 +12,21 @@ describe Protocol::WebSocket::Message do
 	it "can round-trip basic object" do
 		expect(message.to_str).to be == buffer
 	end
+	
+	with "a JSON encoded message" do
+		let(:value) {{hello: "world"}}
+		let(:message) {subject.generate(value)}
+		
+		with "#parse" do
+			it "can parse JSON" do
+				expect(message.parse).to be == {hello: "world"}
+			end
+		end
+		
+		with "#to_h" do
+			it "can convert to hash" do
+				expect(message.to_h).to be == {hello: "world"}
+			end
+		end
+	end
 end


### PR DESCRIPTION
`Protocol::WebSocket::JSONMessage` is clunky. We can introduce `parse` directly on message with a coder argument - and `generate` too.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
