### PR TITLE
Fix error messages for Frame

### DIFF
--- a/lib/protocol/websocket/frame.rb
+++ b/lib/protocol/websocket/frame.rb
@@ -185,7 +185,7 @@ module Protocol
 				end
 				
 				if length > maximum_frame_size
-					raise ProtocolError, "Invalid payload length: #{@length} > #{maximum_frame_size}!"
+					raise ProtocolError, "Invalid payload length: #{length} > #{maximum_frame_size}!"
 				end
 				
 				if mask
@@ -195,7 +195,7 @@ module Protocol
 				payload = stream.read(length) or raise EOFError, "Could not read payload!"
 				
 				if payload.bytesize != length
-					raise EOFError, "Incorrect payload length: #{@length} != #{payload.bytesize}!"
+					raise EOFError, "Incorrect payload length: #{length} != #{payload.bytesize}!"
 				end
 				
 				return self.new(finished, payload, flags: flags, opcode: opcode, mask: mask)

--- a/test/protocol/websocket/frame.rb
+++ b/test/protocol/websocket/frame.rb
@@ -64,7 +64,7 @@ describe Protocol::WebSocket::Frame do
 			
 			expect do
 				subject.read(false, 0, 0, stream, 124)
-			end.to raise_exception(Protocol::WebSocket::ProtocolError, message: be =~ /Invalid payload length/)
+			end.to raise_exception(Protocol::WebSocket::ProtocolError, message: be =~ /Invalid payload length: \d+ > \d*!/)
 		end
 		
 		it "rejects frames with truncated payload" do
@@ -72,7 +72,7 @@ describe Protocol::WebSocket::Frame do
 			
 			expect do
 				subject.read(false, 0, 0, stream, 128)
-			end.to raise_exception(EOFError, message: be =~ /Incorrect payload length/)
+			end.to raise_exception(EOFError, message: be =~ /Incorrect payload length: \d+ != \d+!/)
 		end
 	end
 	


### PR DESCRIPTION
Error messages use instance variable instead of local. This PR fixes it

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
