### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/protocol/websocket/extensions.rb
+++ b/lib/protocol/websocket/extensions.rb
@@ -135,10 +135,7 @@ module Protocol
 				# 	@parameter header [Array(String)] The negotiated extension header tokens.
 				# @returns [Array] The accepted extensions as `[klass, options]` pairs.
 				def accept(headers)
-					extensions = []
-					
 					named = self.named
-					response = []
 					
 					# Each response header should map to at least one extension.
 					Extensions.parse(headers) do |name, arguments|


### PR DESCRIPTION
I use Minitest in some projects, which enables warnings.

### Types of Changes

- Maintenance.

### Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).